### PR TITLE
Allow svcs to take an array of service names

### DIFF
--- a/lib/svcs.js
+++ b/lib/svcs.js
@@ -18,22 +18,21 @@ function svcs(service, cb) {
 
   // make command
   var args = service
-           ? ['-lvp', service]
+           ? ['-lvp'].concat(service)
            : ['-aHo', 'state,fmri'];
+
+  var ret = [];
 
   // make the call
   var child = exec('svcs', args, function(err, stdout, stderr) {
-    var code = err && err.code || 0;
     if (err)
       return cb(err);
     if (!stdout)
       return cb(new Error('No Output'));
 
-    var lines = stdout.trim().split('\n');
-
     // return the list of fmris if no service was specified
     if (!service) {
-      var ret = [];
+      var lines = stdout.trim().split('\n');
       lines.forEach(function(line) {
         var s = strsplit(line, undefined, 2);
         ret.push({
@@ -45,48 +44,58 @@ function svcs(service, cb) {
       return;
     }
 
-    var ret = {};
+    // when passing in multiple service names each section is split by 2 new lines
+    var sections = stdout.trim().split('\n\n');
 
-    // parse the service output line-by-line
-    lines.forEach(function(line) {
-      var split = strsplit(line, undefined, 2);
+    // each section is the output for a single service
+    sections.forEach(function (section) {
+      var lines = section.split('\n');
+      var service = {};
+      // parse the service output line-by-line
+      lines.forEach(function(line) {
+        var split = strsplit(line, undefined, 2);
 
-      // Extract the key and the value
-      var key = split[0];
-      var value = split[1];
+        // Extract the key and the value
+        var key = split[0];
+        var value = split[1];
 
-      // Key specific parsing
-      switch (key) {
-        case 'contract_id':
-          value = parseInt(value, 10);
-          break;
-        case 'enabled':
-          value = value === 'true';
-          break;
-        case 'state_time':
-          value = new Date(value);
-          break;
-        case 'process':
-          var sp = strsplit(value, undefined, 2);
+        // Key specific parsing
+        switch (key) {
+          case 'contract_id':
+            value = parseInt(value, 10);
+            break;
+          case 'enabled':
+            value = value === 'true';
+            break;
+          case 'state_time':
+            value = new Date(value);
+            break;
+          case 'process':
+            var sp = strsplit(value, undefined, 2);
 
-          var obj = {
-            pid: parseInt(sp[0], 10),
-            cmd: sp[1]
-          };
+            var obj = {
+              pid: parseInt(sp[0], 10),
+              cmd: sp[1]
+            };
 
-          value = obj;
+            value = obj;
 
-          if (!ret[key])
-            value = [value];
+            if (!ret[key])
+              value = [value];
 
-          break;
-      }
+            break;
+        }
 
-      // Save the key:value. If the key already exists, make it an array
-      ret[key] = ret[key] ? [].concat(ret[key], value) : value;
+        // Save the key:value. If the key already exists, make it an array
+        service[key] = service[key] ? [].concat(service[key], value) : value;
+      });
+
+      ret.push(service);
+
     });
 
-    return cb(null, ret);
+    return cb(null, ret.length === 1 ? ret[0]: ret);
+
   });
   return child;
 }


### PR DESCRIPTION
Our service tools were getting slow when checking the status of multiple services and I tracked it down to having the execFile get called for every service.  Now you can pass in an array of service names so you only have to do one execFile call and you'll get passed back an array of objects.

Ouptut of svcs -lvp when using multiple service names 
```
fmri         svc:/application/voxer/jpc1-julian-nr1:default
name         Node Router
enabled      true
state        online
next_state   none
state_time   Tue Feb 13 23:38:40 2018
logfile      /var/svc/log/application-voxer-jpc1-julian-nr1:default.log
restarter    svc:/system/svc/restarter:default
contract_id  2718483
dependency   require_all/error svc:/milestone/multi-user:default (online)
process      49720 node --nouse-idle-notification

fmri         svc:/application/voxer/jpc1-julian-nr2:default
name         Node Router
enabled      true
state        online
next_state   none
state_time   Tue Feb 13 23:38:40 2018
logfile      /var/svc/log/application-voxer-jpc1-julian-nr2:default.log
restarter    svc:/system/svc/restarter:default
contract_id  2718482
dependency   require_all/error svc:/milestone/multi-user:default (online)
process      49714 node --nouse-idle-notification
```

Output of calling svcs.stat with multiple service names
```
smf.svcs(['jpc1-julian-nr1', 'jpc1-julian-nr2'], function (err, obj) { console.log(err, obj);})

null [ { fmri: 'svc:/application/voxer/jpc1-julian-nr1:default',
    name: 'Node Router',
    enabled: true,
    state: 'online',
    next_state: 'none',
    state_time: Tue Feb 13 2018 23:38:40 GMT+0000 (UTC),
    logfile: '/var/svc/log/application-voxer-jpc1-julian-nr1:default.log',
    restarter: 'svc:/system/svc/restarter:default',
    contract_id: 2718483,
    dependency: 'require_all/error svc:/milestone/multi-user:default (online)',
    process: [ [Object] ] },
  { fmri: 'svc:/application/voxer/jpc1-julian-nr2:default',
    name: 'Node Router',
    enabled: true,
    state: 'online',
    next_state: 'none',
    state_time: Tue Feb 13 2018 23:38:40 GMT+0000 (UTC),
    logfile: '/var/svc/log/application-voxer-jpc1-julian-nr2:default.log',
    restarter: 'svc:/system/svc/restarter:default',
    contract_id: 2718482,
    dependency: 'require_all/error svc:/milestone/multi-user:default (online)',
    process: [ [Object] ] } ]
```

Output with 1 service name (backward compatibility)
```
smf.svcs(['jpc1-julian-nr1'], function (err, obj) { console.log(err, obj);})

null { fmri: 'svc:/application/voxer/jpc1-julian-nr1:default',
  name: 'Node Router',
  enabled: true,
  state: 'online',
  next_state: 'none',
  state_time: Tue Feb 13 2018 23:38:40 GMT+0000 (UTC),
  logfile: '/var/svc/log/application-voxer-jpc1-julian-nr1:default.log',
  restarter: 'svc:/system/svc/restarter:default',
  contract_id: 2718483,
  dependency: 'require_all/error svc:/milestone/multi-user:default (online)',
  process: 
   [ { pid: 49720,
       cmd: 'node --nouse-idle-notification  } ] }
```